### PR TITLE
Removing redundant sentence

### DIFF
--- a/vector-dot-product-zvdot.adoc
+++ b/vector-dot-product-zvdot.adoc
@@ -11,8 +11,6 @@ These vector dot product instructions are defined with a fixed SEW value of 32. 
 
 The number of body bundles is determined by `vl`. The operation can be masked, each mask bit determines whether the corresponding element result is active or not.
 
-Fractional values of `LMUL` that result in `LMUL*VLEN < SEW` are not supported and cause an illegal instruction exception.
-
 NOTE::
 Future variants could be defined for different SEW values thus:
 [%autowidth]


### PR DESCRIPTION
Citing one of @aswaterman's comment:
"""This sentence is problematic for two reasons:
- It is impossible to configure the vector unit to have `LMUL*VLEN < SEW`; attempting to do so is guaranted to set `vill` to 1.  So it's redundant to say this case will raise an illegal-instruction exception.
- It is somewhat misleading because in fact `LMUL*VLEN < SEW` is not the tightest constraint; implementations might also set `vill` for `LMUL*ELEN < SEW`, even if `LMUL*VLEN >= SEW`."""