### PR TITLE
[#3] Fixing typo Zqvdotq -> Zvqdotq in header

### DIFF
--- a/header.adoc
+++ b/header.adoc
@@ -1,4 +1,4 @@
-= Vector Dot-Product Extension (Zqvdotq)
+= Vector Dot-Product Extension (Zvqdotq)
 :description: The vector dot product extension
 :docgroup: SiFive
 :company: SiFive


### PR DESCRIPTION
Fixing typo raised in https://github.com/riscv/riscv-dot-product/issues/3