### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/build-pdf.yml
+++ b/.github/workflows/build-pdf.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     # Step 1: Checkout the repository
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: 'recursive'
 
@@ -52,7 +52,7 @@ jobs:
 
     # Step 4: Upload the built PDF files as a single artifact
     - name: Upload Build Artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: Build Artifacts
         path: ${{ github.workspace }}/*.pdf


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
